### PR TITLE
TYPE can be specified from the command line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+objects.x86-gcc2-release

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,9 @@ NAME= libsanta
 #	SHARED:	Shared library or add-on
 #	STATIC:	Static library archive
 #	DRIVER: Kernel Driver
-TYPE= STATIC
+# intentionally left blank
+# it is set from the command line
+# it can be either SHARED or STATIC
 
 #	specify the source files to use
 #	full paths or paths relative to the makefile can be included


### PR DESCRIPTION
TYPE can be specified from the command line, since we need to build both static and shared libs
